### PR TITLE
Fixed setting defaultCfNameQueue in RocksDbQueueFactory.

### DIFF
--- a/ddth-queue-core/src/main/java/com/github/ddth/queue/impl/RocksDbQueueFactory.java
+++ b/ddth-queue-core/src/main/java/com/github/ddth/queue/impl/RocksDbQueueFactory.java
@@ -86,7 +86,7 @@ public abstract class RocksDbQueueFactory<T extends RocksDbQueue<ID, DATA>, ID, 
         }
 
         queue.setCfNameEphemeral(defaultCfNameEphemeral).setCfNameMetadata(defaultCfNameMetaData)
-                .setCfNameQueue(defaultCfNameEphemeral);
+                .setCfNameQueue(defaultCfNameQueue);
         String cfNameEphemeral = spec.getField(SPEC_FIELD_CF_EPHEMERAL);
         if (!StringUtils.isBlank(cfNameEphemeral)) {
             queue.setCfNameEphemeral(cfNameEphemeral);


### PR DESCRIPTION
Hi,

Great queue framework! 
I was facing problems with the RocksDBQueue. The default CfName for the Queue was set using the defaultCfNameEphemeral instead of defaultCfNameQueue. Here is the fix.

Cheers,

Jeroen